### PR TITLE
Add Terraform tests and CI

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,26 @@
+name: Terraform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - run: terraform test

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21, < 6.0 |
 
 ## Providers
 

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.21"
+      version = ">= 4.21, < 6.0"
     }
   }
 }

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,81 @@
+mock_provider "aws" {}
+
+run "default_security_group" {
+  command = plan
+
+  variables {
+    name   = "example"
+    vpc_id = "vpc-1234567890abcdef0"
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.name == "example"
+    error_message = "Expected the security group name to match var.name."
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.description == "Security Group for example"
+    error_message = "Expected the default description to use var.name."
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.revoke_rules_on_delete == true
+    error_message = "Expected revoke_rules_on_delete to default to true."
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.tags.Name == "example"
+    error_message = "Expected the Name tag to match the security group name."
+  }
+}
+
+run "typed_security_group" {
+  command = plan
+
+  variables {
+    name   = "example"
+    type   = "web"
+    vpc_id = "vpc-1234567890abcdef0"
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.name == "example-web"
+    error_message = "Expected the security group name to include var.type."
+  }
+
+  assert {
+    condition     = aws_security_group.security_group.description == "Security Group for example-web"
+    error_message = "Expected the default description to include var.type."
+  }
+}
+
+run "security_group_rules" {
+  command = plan
+
+  variables {
+    name   = "example"
+    type   = "web"
+    vpc_id = "vpc-1234567890abcdef0"
+
+    rules = {
+      http = {
+        description              = "HTTP"
+        reciprocal_egress        = true
+        type                     = "ingress"
+        from_port                = 80
+        to_port                  = 80
+        protocol                 = "tcp"
+        cidr_blocks              = ["10.0.0.0/8"]
+        ipv6_cidr_blocks         = null
+        prefix_list_ids          = null
+        source_security_group_id = null
+        self                     = false
+      }
+    }
+  }
+
+  assert {
+    condition     = length(module.sg-rules) == 1
+    error_message = "Expected one security group rule module instance."
+  }
+}

--- a/modules/basic_security_group_rule/README.md
+++ b/modules/basic_security_group_rule/README.md
@@ -16,7 +16,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.21, < 6.0 |
 
 ## Providers
 

--- a/modules/basic_security_group_rule/main.tf
+++ b/modules/basic_security_group_rule/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.21"
+      version = ">= 4.21, < 6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add native Terraform plan tests for security group defaults, typed names, and rule wiring
- add a pull-request Terraform CI workflow
- keep AWS provider resolution on the current v4/v5 line pending a separate provider-v6 review

## Verification
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- terraform test