### PR TITLE
Keep Terraform release tags immutable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,3 @@ jobs:
           tag: ${{ steps.version.outputs.new_version }}
           from-tag: ${{ steps.previous-release.outputs.tag }}
           tag-prefix: v
-          move-major-tag: true
-          move-minor-tag: true


### PR DESCRIPTION
## Summary

- keep Terraform module release tags immutable by not moving floating major/minor tags

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml"); puts "ok"'`
- `rg -i "Pearson|ported from|role arn|account id|iessre|internal workflow|private repo|private org|anothrNick|github-tag-action|branch_name|move-major-tag|move-minor-tag" .github/workflows/main.yml`
- `git diff --check`
